### PR TITLE
Remove `fontCachePath` from settings model

### DIFF
--- a/src/events/ResolveFontCachePathEvent.php
+++ b/src/events/ResolveFontCachePathEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace alps\sharepreviews\events;
+
+use alps\sharepreviews\services\FileHandler;
+use Craft;
+
+/**
+ * @property FileHandler $sender
+ */
+class ResolveFontCachePathEvent extends \yii\base\Event
+{
+    /**
+     * @var string|null The path where you want to cache fonts.
+     */
+    public ?string $path = null;
+}

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -17,20 +17,11 @@ class Settings extends \craft\base\Model
 
     public bool $disableImageCache = false;
 
-    public string $fontCachePath = '';
-
     public bool $showSetUpNavigationItemInCp = true;
 
     private ?string $customFontsPath = null;
 
     private array $templates = [];
-
-    public function __construct($config = [])
-    {
-        parent::__construct($config);
-
-        $this->fontCachePath = Craft::$app->path->getRuntimePath() . '/spfonts';
-    }
 
     public function attributes()
     {


### PR DESCRIPTION
The `fontCachePath` property is being removed from the Settings model.

The default directory where web fonts are cached is [`Craft::$app->path->getRuntimePath() . '/spfonts'`](https://github.com/alpshq/craft-share-previews/blob/1d4f9877c901fc63d3be5ad14bf6c4053b4963d7/src/services/FileHandler.php#L67), which usually evaluates to `storage/runtime/spfonts`.

If you want to customize the directory you can do so by listening to the [`ResolveFontCachePathEvent`](https://github.com/alpshq/craft-share-previews/blob/1d4f9877c901fc63d3be5ad14bf6c4053b4963d7/src/events/ResolveFontCachePathEvent.php) event.
Set your custom path by setting the `path` property one the instance of `ResolveFontCachePathEvent`:

```php
use alps\sharepreviews\events\ResolveFontCachePathEvent;
use alps\sharepreviews\services\FileHandler;
use yii\base\Event;

Event::on(FileHandler::class, FileHandler::EVENT_RESOLVE_FONT_CACHE_PATH, function(ResolveFontCachePathEvent $event) {
    $event->path = 'cache/fonts';
});
```

Thanks @andypullen for bringing this to my attention.