### PR TITLE
Implement SVG support

### DIFF
--- a/src/SharePreviews.php
+++ b/src/SharePreviews.php
@@ -12,6 +12,7 @@ use alps\sharepreviews\services\Fonts;
 use alps\sharepreviews\services\Helpers;
 use alps\sharepreviews\services\ImageDiffer;
 use alps\sharepreviews\services\Images;
+use alps\sharepreviews\services\SvgTransformer;
 use alps\sharepreviews\services\Templates;
 use alps\sharepreviews\services\Urls;
 use alps\sharepreviews\twig\PreviewExtension;
@@ -39,14 +40,15 @@ use GraphQL\Type\Definition\Type;
 use yii\base\Event;
 
 /**
- * @property FileHandler $fileHandler
- * @property Fonts       $fonts
- * @property Helpers     $helpers
- * @property ImageDiffer $imageDiffer
- * @property Images      $images
- * @property Settings    $settings
- * @property Templates   $templates
- * @property Urls        $urls
+ * @property FileHandler    $fileHandler
+ * @property Fonts          $fonts
+ * @property Helpers        $helpers
+ * @property ImageDiffer    $imageDiffer
+ * @property Images         $images
+ * @property Settings       $settings
+ * @property SvgTransformer $svgTransformer
+ * @property Templates      $templates
+ * @property Urls           $urls
  *
  * @method Settings getSettings
  */
@@ -66,6 +68,7 @@ class SharePreviews extends Plugin
             'helpers' => Helpers::class,
             'imageDiffer' => ImageDiffer::class,
             'images' => Images::class,
+            'svgTransformer' => SvgTransformer::class,
             'templates' => Templates::class,
             'urls' => Urls::class,
         ]);

--- a/src/events/ResolveSvgCachePathEvent.php
+++ b/src/events/ResolveSvgCachePathEvent.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace alps\sharepreviews\events;
+
+use alps\sharepreviews\services\FileHandler;
+
+/**
+ * @property FileHandler $sender
+ */
+class ResolveSvgCachePathEvent extends \yii\base\Event
+{
+    /** @var string|null the path where you want to cache fonts */
+    public ?string $path = null;
+}

--- a/src/models/AssetLayer.php
+++ b/src/models/AssetLayer.php
@@ -146,6 +146,12 @@ class AssetLayer extends ImageLayer
             return null;
         }
 
+        if (stristr($asset->mimeType, 'svg') !== false) {
+            return SharePreviews::getInstance()
+                ->svgTransformer
+                ->getPathToTransformedSvg($asset);
+        }
+
         return $asset->getImageTransformSourcePath();
     }
 

--- a/src/services/FileHandler.php
+++ b/src/services/FileHandler.php
@@ -3,6 +3,7 @@
 namespace alps\sharepreviews\services;
 
 use alps\sharepreviews\events\ResolveFontCachePathEvent;
+use alps\sharepreviews\events\ResolveSvgCachePathEvent;
 use alps\sharepreviews\models\fonts\AbstractFontVariant;
 use alps\sharepreviews\models\Image;
 use alps\sharepreviews\models\Settings;
@@ -18,11 +19,15 @@ class FileHandler extends Component
 {
     const EVENT_RESOLVE_FONT_CACHE_PATH = 'resolveFontCachePath';
 
+    const EVENT_RESOLVE_SVG_CACHE_PATH = 'resolveSvgCachePath';
+
     private Settings $settings;
 
     private array $fileCount = [];
 
     private ?string $fontCachePath = null;
+
+    private ?string $svgCachePath = null;
 
     public function __construct($config = [])
     {
@@ -65,6 +70,19 @@ class FileHandler extends Component
         $this->trigger(self::EVENT_RESOLVE_FONT_CACHE_PATH, $event);
 
         return $this->fontCachePath = $event->path ?? Craft::$app->path->getRuntimePath() . '/share-previews/fonts';
+    }
+
+    public function getSvgCachePath(): string
+    {
+        if ($this->svgCachePath) {
+            return $this->svgCachePath;
+        }
+
+        $event = new ResolveSvgCachePathEvent;
+
+        $this->trigger(self::EVENT_RESOLVE_SVG_CACHE_PATH, $event);
+
+        return $this->svgCachePath = $event->path ?? Craft::$app->path->getRuntimePath() . '/share-previews/svgs';
     }
 
     public function getFontPath(AbstractFontVariant $variant): string

--- a/src/services/FileHandler.php
+++ b/src/services/FileHandler.php
@@ -105,7 +105,7 @@ class FileHandler extends Component
         return $this;
     }
 
-    private function ensureDirectoryExists(string $dir): self
+    public function ensureDirectoryExists(string $dir): self
     {
         if (is_dir($dir)) {
             return $this;
@@ -116,7 +116,7 @@ class FileHandler extends Component
         return $this;
     }
 
-    private function ensureGitIgnoreExists(string $dir): self
+    public function ensureGitIgnoreExists(string $dir): self
     {
         $ensure = $this->settings->ensureGitignoreExists;
 

--- a/src/services/FileHandler.php
+++ b/src/services/FileHandler.php
@@ -64,7 +64,7 @@ class FileHandler extends Component
 
         $this->trigger(self::EVENT_RESOLVE_FONT_CACHE_PATH, $event);
 
-        return $this->fontCachePath = $event->path ?? Craft::$app->path->getRuntimePath() . '/spfonts';
+        return $this->fontCachePath = $event->path ?? Craft::$app->path->getRuntimePath() . '/share-previews/fonts';
     }
 
     public function getFontPath(AbstractFontVariant $variant): string

--- a/src/services/SvgTransformer.php
+++ b/src/services/SvgTransformer.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace alps\sharepreviews\services;
+
+use alps\sharepreviews\SharePreviews;
+use craft\elements\Asset;
+use craft\helpers\StringHelper;
+use RuntimeException;
+use yii\base\Component;
+
+class SvgTransformer extends Component
+{
+    private ?FileHandler $fileHandler = null;
+
+    public function __construct($config = [])
+    {
+        parent::__construct($config);
+
+        $this->fileHandler = SharePreviews::getInstance()->fileHandler;
+    }
+
+    public function getPathToTransformedSvg(Asset $asset): string
+    {
+        $path = $this->getPath($asset);
+
+        if (! file_exists($path)) {
+            $this->transform($asset);
+        }
+
+        return $path;
+    }
+
+    private function getPath(Asset $asset): string
+    {
+        $updateDate = $asset->dateUpdated ?? $asset->dateModified ?? $asset->dateCreated;
+        $timestamp = $updateDate?->getTimestamp() ?? 0;
+
+        $filename = StringHelper::slugify($asset->id . ' ' . $timestamp) . '.png';
+
+        return $this->fileHandler->getSvgCachePath() . '/' . $filename;
+    }
+
+    private function transform(Asset $asset): self
+    {
+        if (! $this->isInkscapeAvailable()) {
+            throw new RuntimeException('Inkscape not available. It is required to handle SVG files.');
+        }
+
+        $dir = $this->fileHandler->getSvgCachePath();
+
+        $this
+            ->fileHandler
+            ->ensureDirectoryExists($dir)
+            ->ensureGitIgnoreExists($dir);
+
+        $command = sprintf(
+            'inkscape -w %d %s -o %s',
+            2460,
+            escapeshellarg($asset->getImageTransformSourcePath()),
+            escapeshellarg($this->getPath($asset)),
+        );
+
+        system($command, $output);
+
+        if ($output === 0) {
+            return $this;
+        }
+
+        throw new RuntimeException("SVG transform failed.\n\n" . $output);
+    }
+
+    private function isInkscapeAvailable(): bool
+    {
+        system('which inkscape > /dev/null', $output);
+
+        return $output === 0;
+    }
+}

--- a/src/templates/template-editor/layers/asset.twig
+++ b/src/templates/template-editor/layers/asset.twig
@@ -2,7 +2,7 @@
 {% import '_includes/forms' as forms %}
 
 {% block description %}
-    {{ 'Use an asset layer to add an area where you can place an image.'|t('share-previews') }}
+    {{ 'Use an asset layer to add an area where you can place an image. If you intend to use SVGs, make sure `inkscape` is installed on your server.'|t('share-previews')|md }}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
This PRs adds support for SVGs in asset layers as requested in #11.

`inkscape` is required to be installed on the server.